### PR TITLE
Added PickleDB to substitue for Mongo

### DIFF
--- a/cloudmesh/openapi/command/openapi.py
+++ b/cloudmesh/openapi/command/openapi.py
@@ -8,6 +8,7 @@ from importlib import import_module
 from pathlib import Path
 from shutil import copyfile
 
+from cloudmesh.configuration.Config import Config
 from cloudmesh.common.Printer import Printer
 from cloudmesh.common.console import Console
 from cloudmesh.common.debug import VERBOSE
@@ -195,6 +196,13 @@ class OpenapiCommand(PluginCommand):
                        'host',
                        'basic_auth')
         arguments.debug = arguments.verbose
+        try:
+            Registry.TYPE = Config().get("cloudmesh.registry")
+        except KeyError as e:
+            config = Config()
+            config.set("cloudmesh.registry", "mongo")
+            Registry.TYPE = Config().get("cloudmesh.registry")
+        Console.ok(f"Using {Registry.TYPE} Registry")
 
         #VERBOSE(arguments)
 

--- a/cloudmesh/openapi/registry/DataBaseDecorator.py
+++ b/cloudmesh/openapi/registry/DataBaseDecorator.py
@@ -1,4 +1,5 @@
 from cloudmesh.mongo.CmDatabase import CmDatabase
+from cloudmesh.openapi.registry.PickleDB import PickleDB
 
 
 class DatabaseUpdate:
@@ -79,8 +80,11 @@ class DatabaseUpdate:
     """
 
     # noinspection PyUnusedLocal
-    def __init__(self, **kwargs):
-        self.database = CmDatabase()
+    def __init__(self, provider="cm", **kwargs):
+        if provider == "cm":
+            self.database = CmDatabase()
+        elif provider == "pickle":
+            self.database = PickleDB()
 
     def __call__(self, f):
         def wrapper(*args, **kwargs):

--- a/cloudmesh/openapi/registry/PickleDB.py
+++ b/cloudmesh/openapi/registry/PickleDB.py
@@ -1,0 +1,78 @@
+import os
+import pickle
+from cloudmesh.common.util import path_expand
+from cloudmesh.common.console import Console
+
+
+class PickleDB:
+    def __init__(self, filename="~/.cloudmesh/openapi/registry.p"):
+        expanded_filename = path_expand(filename)
+        os.makedirs(os.path.dirname(expanded_filename), exist_ok=True)
+        self.DB_PATH = expanded_filename
+
+        # Attempt to load from pkl
+        try:
+            self.db = pickle.load(open(expanded_filename, "rb"))
+        except FileNotFoundError as e:
+            self.db = {}
+
+    def update(self, entries):
+        result = []
+        for entry in entries:
+            if "name" not in entry:
+                raise KeyError(
+                    f"No name given for DB entry: {entry}")
+            self.db[entry['name']] = entry
+            result += [entry]
+        return result
+
+    def close_client(self):
+        """
+        Updated DB upon closing client
+        """
+        try:
+            pickle.dump(self.db, open(self.DB_PATH, "wb"))
+            return 0
+        except Exception as e:
+            Console.error(f"Error writing to PickleDB: {e}")
+            return -1
+
+    def clean(self):
+        """
+        Clear DB entries
+        """
+        try:
+            pickle.dump({}, open(self.DB_PATH, "wb"))
+            self.db = {}
+            return 0
+        except:
+            Console.error(f"Error clearing PickleDB at {self.DB_PATH}")
+            return -1
+
+    def delete(self, name):
+        try:
+            entry = self.db[name]
+            del self.db[name]
+            return [entry]
+        except KeyError as e:
+            Console.error(
+                f"KeyError: Could not delete {name} from db. Skipping")
+
+    def find(self, cloud, kind=None):
+        entries = []
+        for entry in self.db:
+            try:
+                if self.db[entry]["cm"]["cloud"] == cloud and self.db[entry]["cm"]["kind"] == kind:
+                    entries += [self.db[entry]]
+            except KeyError as e:
+                Console.error(f"KeyError in PickleDB.find() Skipping: {e}")
+        return entries
+
+    def find_name(self, name, kind=None):
+        entries = []
+        try:
+            if self.db[name]["cm"]["kind"] == kind:
+                entries += [self.db[name]]
+        except KeyError as e:
+            Console.error(f"KeyError. Skipping: {e}")
+        return entries

--- a/cloudmesh/openapi/registry/RegistryMongoDB.py
+++ b/cloudmesh/openapi/registry/RegistryMongoDB.py
@@ -4,7 +4,7 @@ from cloudmesh.mongo.CmDatabase import CmDatabase
 from cloudmesh.mongo.DataBaseDecorator import DatabaseUpdate
 
 
-class Registry:
+class RegistryMongoDB:
     """
       This class will help to register service into db.
       which later use to stop server.
@@ -39,8 +39,8 @@ class Registry:
 
         if output == "table":
 
-            order = self.output[Registry.kind]['order']  # not pretty
-            header = self.output[Registry.kind]['header']  # not pretty
+            order = self.output[RegistryMongoDB.kind]['order']  # not pretty
+            header = self.output[RegistryMongoDB.kind]['header']  # not pretty
             # humanize = self.output[kind]['humanize']  # not pretty
 
             print(Printer.flatwrite(data,
@@ -94,7 +94,7 @@ class Registry:
 
         title = spec["info"]["title"]
 
-        registry = Registry()
+        registry = RegistryMongoDB()
         entry = registry.add(name=title, **kwargs)
 
         return entry


### PR DESCRIPTION
The code changes accomplish the following:
Provide an alternative DB provider in the form of Python Pickle (instead of MongoDB).

To change the Registry used to pickle from the default (mongo), set the following field in cloudmesh config:
```
cms config set cloudmesh.registry=pickle
```
All subsequent interactions with the Registry will be through the Pickle registry. Here is an example with the simple cpu test.
```
cms openapi server start ./tests/server-cpu/cpu.yaml
```
You will notice that the Registry in use is indicated through a Console message.

To switch back to mongo, it is as simple as changing the config again.
```
cms config set cloudmesh.registry=mongo
```