### PR TITLE
Added Registry Protocol Configuration Command

### DIFF
--- a/cloudmesh/openapi/command/openapi.py
+++ b/cloudmesh/openapi/command/openapi.py
@@ -8,7 +8,6 @@ from importlib import import_module
 from pathlib import Path
 from shutil import copyfile
 
-from cloudmesh.configuration.Config import Config
 from cloudmesh.common.Printer import Printer
 from cloudmesh.common.console import Console
 from cloudmesh.common.debug import VERBOSE
@@ -62,6 +61,7 @@ class OpenapiCommand(PluginCommand):
               openapi register filename NAME
               openapi register delete NAME
               openapi register list [NAME] [--output=OUTPUT]
+              openapi register protocol PROTOCOL
               openapi TODO merge [SERVICES...] [--dir=DIR] [--verbose]
               openapi TODO doc FILE --format=(txt|md)[--indent=INDENT]
               openapi TODO doc [SERVICES...] [--dir=DIR]
@@ -73,7 +73,7 @@ class OpenapiCommand(PluginCommand):
               FUNCTION  The name for the function or class
               MODELTAG  The arbirtary name choosen by the user to store the Sklearn trained model as Pickle object
               FILENAME  Path to python file containing the function or class
-              SERVERURL OpenAPI server URL Default: https://localhost:8080/cloudmesh
+              SERVERURL OpenAPI serverprotocolault: https://localhost:8080/cloudmesh
               YAML      Path to yaml file that will contain OpenAPI spec. Default: FILENAME with .py replaced by .yaml
               DIR       The directory of the specifications
               FILE      The specification
@@ -196,13 +196,6 @@ class OpenapiCommand(PluginCommand):
                        'host',
                        'basic_auth')
         arguments.debug = arguments.verbose
-        try:
-            Registry.TYPE = Config().get("cloudmesh.registry")
-        except KeyError as e:
-            config = Config()
-            config.set("cloudmesh.registry", "mongo")
-            Registry.TYPE = Config().get("cloudmesh.registry")
-        Console.ok(f"Using {Registry.TYPE} Registry")
 
         #VERBOSE(arguments)
 
@@ -422,6 +415,10 @@ class OpenapiCommand(PluginCommand):
             result = registry.list(name=arguments.NAME)
 
             registry.Print(data=result, output=arguments.output)
+
+        elif arguments.register and arguments.protocol:
+            result = Registry.protocol(protocol=arguments.PROTOCOL)
+            Console.ok(f"Using Registry Protocol: {result}")
 
         elif arguments.register and arguments['filename']:
 

--- a/tests/test_001_registry.py
+++ b/tests/test_001_registry.py
@@ -11,8 +11,11 @@ from cloudmesh.common.Benchmark import Benchmark
 from cloudmesh.common.util import HEADING
 from cloudmesh.openapi.registry.Registry import Registry
 from cloudmesh.common.variables import Variables
+from cloudmesh.common.util import path_expand
+
+Registry.protocol(protocol="pickle")
 variable=Variables()
-filename= variable['filename']
+filename= variable['filename'] or path_expand('./tests/server-cpu/cpu.yaml')
 # sys.path.append("cloudmesh/openapi/function")
 #
 

--- a/tests/test_002_registry_mongo.py
+++ b/tests/test_002_registry_mongo.py
@@ -14,6 +14,7 @@ from cloudmesh.common.variables import Variables
 from cloudmesh.common.util import path_expand
 
 # Set the yaml file here for protocol=mongo
+Registry.protocol(protocol="mongo")
 variable = Variables()
 filename = variable['filename'] or path_expand('./tests/server-cpu/cpu.yaml')
 # sys.path.append("cloudmesh/openapi/function")
@@ -122,6 +123,3 @@ class TestGenerator:
     def test_benchmark(self):
         HEADING()
         Benchmark.print(csv=True, sysinfo=False, tag="generator")
-
-	def switch_to_pickle(self):
-		pass

--- a/tests/test_002_registry_mongo.py
+++ b/tests/test_002_registry_mongo.py
@@ -1,0 +1,127 @@
+###############################################################
+# pytest -v --capture=no tests/test_03_generator.py
+# pytest -v  tests/test_03_generator.py
+# pytest -v --capture=no  tests/test_generator..py::Test_name::<METHODNAME>
+###############################################################
+from pprint import pprint
+
+import pytest
+import yaml as yaml
+from cloudmesh.common.Benchmark import Benchmark
+from cloudmesh.common.util import HEADING
+from cloudmesh.openapi.registry.Registry import Registry
+from cloudmesh.common.variables import Variables
+from cloudmesh.common.util import path_expand
+
+# Set the yaml file here for protocol=mongo
+variable = Variables()
+filename = variable['filename'] or path_expand('./tests/server-cpu/cpu.yaml')
+# sys.path.append("cloudmesh/openapi/function")
+#
+
+
+#
+# get the spec for the tests
+#
+
+with open(filename, "r") as stream:
+    try:
+        spec = yaml.safe_load(stream)
+    except yaml.YAMLError as e:
+        print(e)
+        assert False, "Yaml file has syntax error"
+
+
+@pytest.mark.incremental
+class TestGenerator:
+
+    def test_registry_add(self):
+        HEADING()
+
+        Benchmark.Start()
+
+        title = spec["info"]["title"]
+        url = spec["servers"][0]["url"]
+
+        print(f"add {title} -> {url}")
+        registry = Registry()
+
+        before = len(registry.list(name=title))
+
+        pid = 1
+
+        entry = registry.add(name=title, url=url, pid=pid)
+        pprint(entry)
+
+        after = len(registry.list(name=title))
+
+        assert after == before + 1
+
+        Benchmark.Stop()
+
+    def test_registry_list_name(self):
+        HEADING()
+
+        Benchmark.Start()
+
+        title = spec["info"]["title"]
+
+        registry = Registry()
+
+        entry = registry.list(name=title)
+        pprint(entry)
+
+        assert entry != None
+
+        Benchmark.Stop()
+
+    def test_registry_list(self):
+        HEADING()
+
+        Benchmark.Start()
+
+        title = spec["info"]["title"]
+
+        #print(f"delete {title}")
+        registry = Registry()
+
+        entry = registry.list()
+        pprint(entry)
+
+        assert len(entry) > 0
+
+        Benchmark.Stop()
+
+    def test_registry_delete(self):
+        HEADING()
+
+        Benchmark.Start()
+
+        title = spec["info"]["title"]
+
+        registry = Registry()
+        entry = registry.list(name=title)
+
+        # list before and use len()
+        #before = 1
+        before = len(entry)
+
+        print(f"delete {title}")
+
+        entry = registry.delete(name=title)
+        print(f"{entry} entry deleted")
+
+        # list after and use len
+
+        after = len(registry.list(name=title))  # use len()
+
+        assert before == after + 1
+
+        Benchmark.Stop()
+
+    def test_benchmark(self):
+        HEADING()
+        Benchmark.print(csv=True, sysinfo=False, tag="generator")
+
+	def switch_to_pickle(self):
+		pass


### PR DESCRIPTION
This PR adds the following command to `cms openapi`:
```
> cms openapi register protocol PROTOCOL
```

For example, to switch to Pickle DB, use the following:
```
> cms openapi register protocol pickle
```

All subsequent commands that involve using the Registry will use the Registry Protocol dictated using the above command. In essence, this command sets the DB provider. 

We may also switch to mongo:
```
> cms openapi register protocol mongo
```

Pickle DB works "out of the box" with cms openapi. See the README for further notes on configuring cms openapi with MongoDB.

Note that this may be manually set in the cloudmesh config file. The config option is `cloudmesh.registry.microservice.default.protocol`

See pytest commit for unit tests.